### PR TITLE
Adding FoxyCart to the ecommerce section

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@
 
 ## E-Commerce
 
+* [FoxyCart](http://www.foxycart.com/)
 * [Google Checkout](https://checkout.google.com/seller/integrate_shoppingcart.html)
 * [Gumroad](https://gumroad.com/)
 * [Jekyll-Store](https://github.com/jekyll-store/front)


### PR DESCRIPTION
It feels awkward to add it to the beginning of the list, but it's alphabetized, so that's where it'd fit.