### PR TITLE
Added netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@
 * [Divshot](https://divshot.com/)
 * [Github Pages](https://pages.github.com/)
 * [Pancake](https://pancake.io/)
+* [Netlify](https://www.netlify.com/)
 * [paperplane.io](https://www.paperplane.io/)- $9/month
 
 ## Email Services for Developers


### PR DESCRIPTION
Bumped it up above paperplane.io, because they have a generous free plan, like most of the rest in that list.