### PR TITLE
Add frameit.dev

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,6 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Cloudinary](https://cloudinary.com/) - Image hosting, manipulation and delivery.
 - [frameit.dev](https://frameit.dev) — Generate OpenGraph images, YouTube thumbnails, title cards and banners in the browser
 
-
 ## Maps
 
 - [Google Maps](http://maps.google.com/) - Google maps are easily embeddable.

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,8 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [Flickr](https://www.flickr.com/) - Online photo hosting by Yahoo.
 - [Cloudinary](https://cloudinary.com/) - Image hosting, manipulation and delivery.
+- [frameit.dev](https://frameit.dev) — Generate OpenGraph images, YouTube thumbnails, title cards and banners in the browser
+
 
 ## Maps
 


### PR DESCRIPTION
Adding frameit.dev — a free OpenGraph / thumbnail generator that works in the browser. Useful for devs, SaaS apps, and content creators.