### PR TITLE
Add BulkPicTools - WASM-powered image utility for static workflows

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,8 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [Flickr](https://www.flickr.com/) - Online photo hosting by Yahoo.
 - [Cloudinary](https://cloudinary.com/) - Image hosting, manipulation and delivery.
+- [BulkPicTools](https://bulkpictools.com) - A privacy-first, browser-based batch image processor for static site creators, leveraging WebAssembly for local compression and conversion.
+
 
 ## Maps
 


### PR DESCRIPTION
Why add this?
As a fan of the static web ecosystem, I built BulkPicTools to solve a common pain point for static site developers: optimizing images without relying on heavy server-side APIs or privacy-invasive third-party uploads.