### PR TITLE
Add Remove Audio to Utilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -254,6 +254,7 @@ Third party integration:
 
 ## Utilities
 - [BulkPicTools](https://bulkpictools.com) - A privacy-first, browser-based batch image processor for static site creators, leveraging WebAssembly for local compression and conversion.
+- [remove-audio.com](https://remove-audio.com) - A privacy-first, browser-based batch video muter for static site creators, stripping the audio track from screencasts and demo clips locally via WebAssembly with no uploads or watermarks.
 
 ## Other
 


### PR DESCRIPTION
Adds Remove Audio to the Utilities section.

BulkPicTools (already in this section) is a privacy-first, WebAssembly, browser-based batch image processor aimed at static site creators. Remove Audio is the same shape for video: a privacy-first, WebAssembly + FFmpeg.wasm, browser-based batch video muter aimed at the same audience (muting screencasts and demo clips before embedding them in a static site). Free, no uploads, no watermarks, batch up to 20 clips. Format mirrors the existing Utilities entry; single suggestion, single PR.